### PR TITLE
Render description for UneditableField

### DIFF
--- a/examples/uneditable_field.html
+++ b/examples/uneditable_field.html
@@ -28,7 +28,8 @@
 			new Y.inputEx.UneditableField({
 				name: 'date', 
 				value: new Date(), 
-				parentEl: 'container1'
+				parentEl: 'container1',
+				description: "Current Date"
 			});
 		</pre>
 	</div>
@@ -49,7 +50,8 @@
 					visuType: 'func', 
 					func: function(value){ return inputEx.cn('img',{src:value},{border: '2px solid black'}); } 
 				},
-				parentEl: 'container2' 
+				parentEl: 'container2',
+				description: "An Image"
 			});
 		</pre>
 	</div>

--- a/src/inputex-uneditable/inputex-uneditable.js
+++ b/src/inputex-uneditable/inputex-uneditable.js
@@ -33,6 +33,15 @@ Y.extend(inputEx.UneditableField, inputEx.Field, {
    },
    
    /**
+    * Render only a wrapper. It will be filled in by setValue
+    * @method renderComponent
+    */
+   renderComponent: function() {
+      this.wrapEl = inputEx.cn('div', {className: 'inputEx-UneditableField-wrapper'});
+      this.fieldContainer.appendChild(this.wrapEl);
+   },
+
+   /**
     * Store the value and update the visu
     * @method setValue
     * @param {Any} val The value that will be sent to the visu
@@ -41,7 +50,7 @@ Y.extend(inputEx.UneditableField, inputEx.Field, {
    setValue: function(val, sendUpdatedEvt) {
       this.value = val;
       
-      inputEx.renderVisu(this.options.visu, val, this.fieldContainer);
+      inputEx.renderVisu(this.options.visu, val, this.wrapEl);
       
 	   inputEx.UneditableField.superclass.setValue.call(this, val, sendUpdatedEvt);
    },


### PR DESCRIPTION
UneditableField attempts to render a description, then immediately clobbers it in setValue.  I fixed it so setValue will render inside a wrapper and leave the description there.